### PR TITLE
#163722551: users should be able to view menu items

### DIFF
--- a/src/components/ClientComponent.jsx
+++ b/src/components/ClientComponent.jsx
@@ -6,7 +6,7 @@ import InputField from './utils/InputField';
 import SignupButton from './utils/SignupButton';
 
 
-class AdminComponent extends Component {
+class ClientComponent extends Component {
   // eslint-disable-next-line class-methods-use-this
   componentDidMount() {
     document.addEventListener('DOMContentLoaded', () => {
@@ -42,11 +42,11 @@ class AdminComponent extends Component {
             <a className="btn-floating btn-large waves-effect waves-light btn modal-trigger click-add" href="#modal1"><i className="material-icons">add</i></a>
             <div id="modal1" className="modal add-form s12 m4 l3">
               <div className="modal-content">
-                <h4>New food item</h4>
+                <h4>Place your order</h4>
                 <form>
                   <InputField item="item" onChange={onChange}/>
-                  <InputField item="price" onChange={onChange}/>
-                  <SignupButton name="Add" onClick={onClick}/>
+                  <InputField item="quantity" onChange={onChange}/>
+                  <SignupButton name="Order" onClick={onClick}/>
                 </form>
               </div>
             </div>
@@ -57,9 +57,9 @@ class AdminComponent extends Component {
   }
 }
 
-AdminComponent.propTypes = {
+ClientComponent.propTypes = {
   onChange: PropTypes.func,
   onClick: PropTypes.func,
 };
 
-export default AdminComponent;
+export default ClientComponent;

--- a/src/redux/actions/MenuActions.js
+++ b/src/redux/actions/MenuActions.js
@@ -1,8 +1,13 @@
-import { ADD_MENU_ITEM } from './types';
+import { ADD_MENU_ITEM, GET_MENU } from './types';
 
 const addMenuItem = message => ({
   type: ADD_MENU_ITEM,
   message,
 });
 
-export default addMenuItem;
+const getMenu = menu => ({
+  type: GET_MENU,
+  menu,
+});
+
+export { addMenuItem, getMenu };

--- a/src/redux/actions/types.js
+++ b/src/redux/actions/types.js
@@ -1,3 +1,4 @@
 export const SIGNUP_USER = 'SIGNUP_USER';
 export const ERROR_OCCURED = 'ERROR_OCCURED';
 export const ADD_MENU_ITEM = 'ADD_MENU_ITEM';
+export const GET_MENU = 'GET_MENU';

--- a/src/redux/reducers/MenuReducer.js
+++ b/src/redux/reducers/MenuReducer.js
@@ -1,4 +1,4 @@
-import { ADD_MENU_ITEM, ERROR_OCCURED } from '../actions/types';
+import { ADD_MENU_ITEM, ERROR_OCCURED, GET_MENU } from '../actions/types';
 
 const initialState = {
   message: null,
@@ -11,6 +11,13 @@ const menuReducer = (state = initialState, action) => {
       return {
         ...state,
         message: action.message,
+        error: '',
+      };
+    case GET_MENU:
+      return {
+        ...state,
+        menu: action.menu,
+        message: '',
         error: '',
       };
     case ERROR_OCCURED:

--- a/src/redux/reducers/__tests__/menuReducer.test.js
+++ b/src/redux/reducers/__tests__/menuReducer.test.js
@@ -1,5 +1,5 @@
 import menuReducer from '../MenuReducer';
-import addMenuItem from '../../actions/MenuActions';
+import { addMenuItem, getMenu } from '../../actions/MenuActions';
 import errorOccured from '../../actions/errorAction';
 
 const initialState = {
@@ -19,6 +19,17 @@ describe('auth reducer', () => {
     };
     expect(
       menuReducer(initialState, addMenuItem('Food option added successfuly')),
+    ).toEqual(expected);
+  });
+
+  it('should return menu', () => {
+    const expected = {
+      error: '',
+      menu: { item: 'rice', price: '2000' },
+      message: '',
+    };
+    expect(
+      menuReducer(initialState, getMenu({ item: 'rice', price: '2000' })),
     ).toEqual(expected);
   });
 

--- a/src/redux/thunks/__tests__/menuActions.test.js
+++ b/src/redux/thunks/__tests__/menuActions.test.js
@@ -1,9 +1,9 @@
 import thunk from 'redux-thunk';
 import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
-import addMenuItem from '../../actions/MenuActions';
-import { postDataThunkPrivate, axiosInstance } from '..';
-import { ADD_MENU_ITEM, ERROR_OCCURED } from '../../actions/types';
+import { addMenuItem, getMenu } from '../../actions/MenuActions';
+import { postDataThunkPrivate, axiosInstance, getDataThunkPublic } from '..';
+import { ADD_MENU_ITEM, ERROR_OCCURED, GET_MENU } from '../../actions/types';
 
 describe('auth actions', () => {
   let httpMock;
@@ -33,6 +33,43 @@ describe('auth actions', () => {
       .dispatch(postDataThunkPrivate('menu', menuData, addMenuItem, 'post'))
       .then(() => {
         expect(store.getActions()).toEqual([{ type: ADD_MENU_ITEM, message: response }]);
+      });
+  });
+
+  it('should return menu', () => {
+    const response = [
+      {
+        item: 'chips',
+        price: '2000',
+      },
+      {
+        item: 'chbnn',
+        price: '2000',
+      },
+    ];
+
+    httpMock.onGet('menu').reply(200, response);
+    // eslint-disable-next-line jest/valid-expect-in-promise
+    store
+      .dispatch(getDataThunkPublic('menu', getMenu))
+      .then(() => {
+        expect(store.getActions()).toEqual([{ type: GET_MENU, menu: response }]);
+      });
+  });
+
+  it('should return error on fetch menu', () => {
+    const response = {
+      error: {
+        message: 'No available food items',
+      },
+    };
+
+    httpMock.onGet('menu').reply(404, response);
+    // eslint-disable-next-line jest/valid-expect-in-promise
+    store
+      .dispatch(getDataThunkPublic('menu', getMenu))
+      .then(() => {
+        expect(store.getActions()).toEqual([{ type: ERROR_OCCURED, error: response }]);
       });
   });
 

--- a/src/redux/thunks/index.js
+++ b/src/redux/thunks/index.js
@@ -18,6 +18,14 @@ const postDataThunkPublic = (endpoint, data, actionCreator, method) => (dispatch
   });
 };
 
+const getDataThunkPublic = (endpoint, actionCreator) => (dispatch) => {
+  return axiosInstance.get(endpoint).then((response) => {
+    dispatch(actionCreator(response.data));
+  }).catch((err) => {
+    dispatch(errorOccured(err));
+  });
+};
+
 const postDataThunkPrivate = (endpoint, data, actionCreator, method) => (dispatch) => {
   const token = localStorage.getItem('token');
 
@@ -29,4 +37,6 @@ const postDataThunkPrivate = (endpoint, data, actionCreator, method) => (dispatc
   });
 };
 
-export { postDataThunkPublic, postDataThunkPrivate, axiosInstance };
+export {
+  postDataThunkPublic, postDataThunkPrivate, axiosInstance, getDataThunkPublic,
+};

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -6,6 +6,7 @@ import HomeView from '../views/HomeView';
 import LoginView from '../views/LoginView';
 import SignupView from '../views/SignupView';
 import AdminView from '../views/AdminView';
+import ClientView from '../views/ClientView';
 
 
 export const store = configureStore();
@@ -19,6 +20,7 @@ const Routes = () => {
           <Route path="/login" component={LoginView} />
           <Route path="/signup" component={SignupView} />
           <Route path="/admin" component={AdminView} />
+          <Route path="/client" component={ClientView} />
         </Switch>
       </BrowserRouter>
     </Provider>

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import 'msg-notify/dist/notify.css';
 import notify from 'msg-notify';
+import PropTypes from 'prop-types';
 import AdminComponent from '../components/AdminComponent';
-import { postDataThunkPrivate } from '../redux/thunks';
-import addMenuItem from '../redux/actions/MenuActions';
+import { postDataThunkPrivate, getDataThunkPublic } from '../redux/thunks';
+import { addMenuItem, getMenu } from '../redux/actions/MenuActions';
 
 
 export class AdminView extends Component {
@@ -13,6 +14,11 @@ export class AdminView extends Component {
     price: '',
     success: '',
     error: '',
+  }
+
+  componentDidMount() {
+    const { getDataThunkPublic } = this.props;
+    getDataThunkPublic('menu', getMenu);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -25,6 +31,7 @@ export class AdminView extends Component {
       this.setState({
         success: successMessage,
       });
+      window.location.reload();
     } else if (message) {
       const errorShow = message.price || message;
       notify(errorShow, 'error');
@@ -49,8 +56,9 @@ export class AdminView extends Component {
   }
 
   render() {
+    const { menu } = this.props;
     return (
-      <AdminComponent onChange={this.handleChange} onClick={this.handleClick}/>
+      <AdminComponent onChange={this.handleChange} onClick={this.handleClick} menu={menu}/>
     );
   }
 }
@@ -59,11 +67,18 @@ const mapStateToProps = (state) => {
   return {
     error: state.menuReducer.error,
     success: state.menuReducer.message,
+    menu: state.menuReducer.menu,
   };
 };
 
 const actionCreators = {
   postDataThunkPrivate,
+  getDataThunkPublic,
+};
+
+AdminView.propTypes = {
+  getDataThunkPrivate: PropTypes.func,
+  postDataThunkPrivate: PropTypes.func,
 };
 
 export default connect(mapStateToProps, actionCreators)(AdminView);

--- a/src/views/ClientView.jsx
+++ b/src/views/ClientView.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import ClientComponent from '../components/ClientComponent';
+import { getDataThunkPublic } from '../redux/thunks';
+import { getMenu } from '../redux/actions/MenuActions';
+
+class ClientView extends Component {
+  componentDidMount() {
+    const { getDataThunkPublic } = this.props;
+    getDataThunkPublic('menu', getMenu);
+  }
+
+  render() {
+    const { menu } = this.props;
+    return (
+      <ClientComponent menu={menu} />
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    menu: state.menuReducer.menu,
+  };
+};
+
+const actionCreators = {
+  getDataThunkPublic,
+};
+
+export default connect(mapStateToProps, actionCreators)(ClientView);

--- a/src/views/__tests__/AdminView.test.js
+++ b/src/views/__tests__/AdminView.test.js
@@ -13,8 +13,19 @@ describe('admin view', () => {
 
   let props = {
     postDataThunkPrivate: jest.fn(),
+    getDataThunkPublic: jest.fn(),
     error: null,
     successMessage: null,
+    menu: [
+      {
+        item: 'chips',
+        price: '2000',
+      },
+      {
+        item: 'chbnn',
+        price: '2000',
+      },
+    ],
   };
 
   const initialState = {
@@ -25,6 +36,7 @@ describe('admin view', () => {
   beforeEach(() => {
     store = mockStore(initialState);
     store.dispatch = jest.fn();
+    window.location.reload = jest.fn();
   });
 
   it('renders conatainer with chikd component successfully', () => {
@@ -46,12 +58,23 @@ describe('admin view', () => {
     store = mockStore(state);
     props = {
       postDataThunkPrivate: jest.fn(),
+      getDataThunkPublic: jest.fn(),
       error: {
         message: '',
       },
       successMessage: {
         message: 'Food option added successfuly',
       },
+      menu: [
+        {
+          item: 'chips',
+          price: '2000',
+        },
+        {
+          item: 'chbnn',
+          price: '2000',
+        },
+      ],
     };
     wrapper = mount(<Provider store={store}>
       <AdminPage {...props}/>
@@ -83,10 +106,10 @@ describe('admin view', () => {
     wrapper = mount(<AdminView {...props}/>);
     wrapper.setProps({
       postDataThunkPrivate: jest.fn(),
+      getDataThunkPublic: jest.fn(),
       error: '',
       success: { message: 'Food option added successfuly' },
     }, () => {
-      console.log(wrapper.state());
       expect(wrapper.state()).toEqual(state);
     });
   });
@@ -95,13 +118,25 @@ describe('admin view', () => {
     const historyMock = { push: jest.fn() };
     props = {
       postDataThunkPrivate: jest.fn(),
+      getDataThunkPublic: jest.fn(),
       successMessage: null,
       error: { price: 'Please provide price, provide food item as well' },
+      menu: [
+        {
+          item: 'chips',
+          price: '2000',
+        },
+        {
+          item: 'chbnn',
+          price: '2000',
+        },
+      ],
     };
 
     wrapper = mount(<AdminView {...props} history={historyMock}/>);
     wrapper.setProps({
       postDataThunkPublic: jest.fn(),
+      getDataThunkPublic: jest.fn(),
       error: { message: { price: 'Please provide price, provide food item as well' } } ,
       message: null,
     });


### PR DESCRIPTION
What does this PR do?
Add user functionality of viewing menu items.

Description of tasks to be completed?
- Create view menu action creators.
- Modify menu reducer with view menu action
- Modify admin component by removing dummy menu items

How can this be manually tested?
- Clone the repository.
- Check out this branch `ft-view-menu-163722551`.
- Login and the menu items will be on the dashboard.

What are the related pivotal tracker stories?
#163722551

Screenshots?
![image](https://user-images.githubusercontent.com/40595048/52463616-99f49380-2b88-11e9-9702-656d3c02d487.png)
